### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # `docker.io/paketobuildpacks/appdynamics`
-The Paketo AppDynamics Buildpack is a Cloud Native Buildpack that contributes the [AppDynamics][n] Agent and configures it to
+The Paketo Buildpack for AppDynamics is a Cloud Native Buildpack that contributes the [AppDynamics][n] Agent and configures it to
 connect to the service.
 
 [a]: https://www.appdynamics.com

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/appdynamics"
   id = "paketo-buildpacks/appdynamics"
   keywords = ["appdynamics", "agent", "apm", "java", "nodejs"]
-  name = "Paketo AppDynamics Buildpack"
+  name = "Paketo Buildpack for AppDynamics"
   sbom-formats = ["application/vnd.syft+json", "application/vnd.cyclonedx+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo AppDynamics Buildpack' to 'Paketo Buildpack for AppDynamics'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
